### PR TITLE
このドキュメントが古いものであることを示す

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-2.2-20141018225750+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2-bin.zip

--- a/subprojects/docs/src/docs/stylesheets/userGuideHtml.xsl
+++ b/subprojects/docs/src/docs/stylesheets/userGuideHtml.xsl
@@ -29,6 +29,10 @@
     <xsl:template name="header.navigation">
         <xsl:param name="next"/>
         <xsl:param name="prev"/>
+        <p style="border-radius: 5px; padding: 0.8em; line-height: 1.3;background-color: #FFC107;">
+            この翻訳はGradle バージョン2.2時点のものです。2020年10月時点でもGradleの最新版はバージョン5.7であり、
+            その間に数多く仕様変更がありました。そのため最新情報は公式ドキュメントを確認してください。
+        </p>
         <xsl:if test=". != /book">
             <div class='navheader'>
                 <xsl:call-template name="navlinks">


### PR DESCRIPTION
こちらのサイトはGoogle検索などでよく引っかかります。
しかしこちらの日本語訳はもととなっているバージョンが古く、今推奨されない方法で書かれていることもあります。
そのため入門者がこちらのサイトを鵜呑みにしてしまうのは良くないと思います。
そのため、古いことを明記すべきだと思いました。

個人的な意見ですが、Google検索などで引っかかってしまう状態でサイトの削除はふさわしくないと思うので、サイトの削除はしないでいただけると幸いです。